### PR TITLE
Fix Drafts list rendering

### DIFF
--- a/pubs.html
+++ b/pubs.html
@@ -15,12 +15,8 @@
 
 <div class="section"><a name="drafts" href="#drafts" class="selflink">Drafts</a></div>
 <ul>
-  <li><p><em>An Existential Crisis Resolved: Type inference for first-class existential types</em>. Richard A. Eisenberg, Guillaume Duboc, Stephanie Weirich, and Daniel Lee. Draft, 2021. (<a href="papers/2021/exists/exists.pdf">pdf</a>)
-  </li>
-<ul>
-  <li><p><em>Linear Constraints</em>. Jean-Philippe Bernardy, Richard A. Eisenberg, Csongor Kiss, Arnaud Spiwack, and Nicolas Wu. Draft, 2021. (<a href="papers/2021/linear-constraints/linear-constraints.pdf">pdf</a>)
-  </li>
-<ul>
+  <li><p><em>An Existential Crisis Resolved: Type inference for first-class existential types</em>. Richard A. Eisenberg, Guillaume Duboc, Stephanie Weirich, and Daniel Lee. Draft, 2021. (<a href="papers/2021/exists/exists.pdf">pdf</a>)</p></li>
+  <li><p><em>Linear Constraints</em>. Jean-Philippe Bernardy, Richard A. Eisenberg, Csongor Kiss, Arnaud Spiwack, and Nicolas Wu. Draft, 2021. (<a href="papers/2021/linear-constraints/linear-constraints.pdf">pdf</a>)</p></li>
   <li><p><em>Seeking Stability by being Lazy and Shallow: Lazy and shallow instantiation is user friendly</em>. Gert-Jan Bottu and Richard A. Eisenberg. Draft, 2021. (<a href="papers/2021/stability/stability.pdf">pdf</a>)</p></li>
 </ul>
 


### PR DESCRIPTION
The [Drafts](https://richarde.dev/pubs.html#drafts) list is rendered funnily: a quick look at the git history tells me that this used to be a single `<ul>`, so I changed it back to a single list.