### PR TITLE
Update link for Stitch talk

### DIFF
--- a/pubs.html
+++ b/pubs.html
@@ -52,7 +52,7 @@
       (<a href="papers/2020/kinds-are-cc/kinds-are-cc.pdf">pdf</a>)</p></li>
 
   <li><p><em>Stitch: The Sound Type-Indexed Type Checker, a Functional Pearl</em>. Richard A. Eisenberg. Haskell Symposium 2020.
-      (<a href="papers/2018/stitch/stitch.pdf">pdf</a> <a href="papers/2018/stitch/stitch.tar.gz">tarball</a> <a href="https://gitlab.com/goldfirere/stitch">source repo</a> <a href="talks/2018/stitch/nyc-stitch-slides.pdf">slides from talk at NYC Haskell</a> <a href="talks/2019/stitch/zurihac-stitch-slides.pdf">ZuriHac slides</a> <a href="papers/2018/stitch/stitch-slides.pdf">Haskell Symposium slides</a> <a href="https://youtu.be/rA9GRODf1zU">Haskell Symposium talk</a>)</p></li>
+      (<a href="papers/2018/stitch/stitch.pdf">pdf</a> <a href="papers/2018/stitch/stitch.tar.gz">tarball</a> <a href="https://gitlab.com/goldfirere/stitch">source repo</a> <a href="talks/2018/stitch/nyc-stitch-slides.pdf">slides from talk at NYC Haskell</a> <a href="talks/2019/stitch/zurihac-stitch-slides.pdf">ZuriHac slides</a> <a href="papers/2018/stitch/stitch-slides.pdf">Haskell Symposium slides</a> <a href="https://www.youtube.com/watch?v=lsGHa-pdCCs">Haskell eXchange talk</a>)</p></li>
 
   <li><p><em>Composing Effects into Tasks and Workflows</em>. Yves Par&egrave;s, Jean-Philippe Bernardy, and Richard A. Eisenberg. Haskell Symposium 2020.
       (<a href="papers/2020/workflows/workflows.pdf">pdf</a> <a href="https://github.com/tweag/kernmantle">source repo</a>)</p></li>


### PR DESCRIPTION
Hi, I just noticed this link is broken. Since I really enjoyed the quality of the recording of that same talk you gave at Haskell eXchange 2019 (partly due to the speaker-tracking camera), I changed the link to https://www.youtube.com/watch?v=lsGHa-pdCCs.

Also, lower in the same file there is: https://github.com/goldfirere/web/blob/de662314b5bf8dc007e463574ea9b4de5f6c645c/pubs.html#L179

Since the link is broken there as well, it might be uesful to swap out this list item for the Haskell eXchange talk entirely, if you like that particular recording as well (of course I could make that change for you, if you'd like).